### PR TITLE
refactor(theming): add type definitions for the theme object

### DIFF
--- a/example/src/stories/BarChart.stories.tsx
+++ b/example/src/stories/BarChart.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {BarChart} from "@loadsmart/data-visualization";
+import {BarChart, ThemeType} from "@loadsmart/data-visualization";
 import {Story} from "@storybook/react/types-6-0";
 
 export default {
@@ -61,8 +61,8 @@ const mockData = [
   },
 ]
 
-const Template:Story = (args) => <BarChart data={mockData} colors={args.colors} valueFormatter={args.valueFormatter} theme={
-  {
+const Template:Story = (args) => {
+  const theme:ThemeType = {
     charts: {
       bar: {
         fill: args.fill,
@@ -80,7 +80,8 @@ const Template:Story = (args) => <BarChart data={mockData} colors={args.colors} 
       }
     }
   }
-}/>
+  return <BarChart data={mockData} colors={args.colors} valueFormatter={args.valueFormatter} theme={theme}/>
+}
 
 export const DefaultTheme = Template.bind({})
 DefaultTheme.args = {}

--- a/example/src/stories/Button.stories.tsx
+++ b/example/src/stories/Button.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {Meta, Story} from '@storybook/react/types-6-0';
 
 // @ts-ignore
-import {Button, ButtonProps} from '@loadsmart/data-visualization'
+import {Button, ButtonProps, ThemeType} from '@loadsmart/data-visualization'
 import {ThemeProvider} from "styled-components";
 
 export default {
@@ -37,7 +37,7 @@ export default {
 
 const Template: Story<ButtonProps> = (args) => <Button {...args}>{args.children}</Button>;
 
-const freshThemeOfBelAir = {
+const freshThemeOfBelAir:ThemeType = {
   button: {
     active: {
       background: 'mediumpurple',

--- a/example/src/stories/Card.stories.tsx
+++ b/example/src/stories/Card.stories.tsx
@@ -3,7 +3,7 @@ import React, {ChangeEvent, MouseEvent, ReactNode} from 'react';
 import {Meta, Story} from '@storybook/react/types-6-0';
 
 // @ts-ignore
-import {Card, CardContentProps, CardProps, CardTitleProps} from '@loadsmart/data-visualization'
+import {Card, CardContentProps, CardProps, CardTitleProps, ThemeType} from '@loadsmart/data-visualization'
 
 export default {
   title: 'Card',
@@ -187,7 +187,7 @@ interface StoryType {
 }
 
 const FullTemplate: Story<StoryType> = (args) => {
-  const theme = args.customTheme ? {
+  const theme:ThemeType = args.customTheme ? {
     card: {
       background: args.background,
       padding: `${args.padding}px`,
@@ -219,7 +219,7 @@ const FullTemplate: Story<StoryType> = (args) => {
         }
       }
     }
-  } : undefined
+  } : {}
 
   const cardProps: CardProps = {
     theme

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-eslint": "^10.0.3",
     "commitizen": "^4.2.3",
     "cross-env": "^7.0.2",
+    "csstype": "^3.0.7",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.7.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,3 +14,6 @@ export type {
   BarChartDataType,
   BarChartColorsType
 } from './components/BarChart'
+
+export type { ThemeType } from './theme'
+export { default as DefaultTheme, defaultValues } from './theme'

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -1,8 +1,17 @@
+import * as CSS from 'csstype'
+
 import colors from './values/colors'
 import dimensions from './values/dimensions'
 import typography from './values/typography'
+import {
+  BarChartType,
+  BaseButtonType,
+  ButtonType,
+  CardType,
+  ThemeType
+} from './types'
 
-const baseButton = {
+const baseButton: BaseButtonType = {
   background: colors.neutral.lightest,
   padding: dimensions.pixels.small,
   border: {
@@ -14,10 +23,11 @@ const baseButton = {
     color: colors.neutral.darkest,
     size: typography.button.size,
     weight: typography.button.weight,
-    transform: typography.button.transform
+    transform: typography.button.transform as CSS.Property.TextTransform
   }
 }
-const button = {
+
+const button: ButtonType = {
   regular: {
     ...baseButton
   },
@@ -31,7 +41,7 @@ const button = {
   }
 }
 
-const card = {
+const card: CardType = {
   background: colors.neutral.lightest,
   padding: dimensions.pixels.large,
   shadow: '0px 1px 2px rgba(0, 0, 0, 0.1)',
@@ -53,7 +63,7 @@ const card = {
       background: colors.neutral.lighter,
       border: {
         radius: dimensions.pixels.largest,
-        width: dimensions.pixels.zero
+        width: dimensions.pixels.zero as CSS.Property.Width
       },
       width: dimensions.pixels.larger,
       height: dimensions.pixels.larger,
@@ -63,7 +73,7 @@ const card = {
   }
 }
 
-const bar = {
+const bar: BarChartType = {
   fill: colors.status.danger.dark,
   size: dimensions.number.large,
   value: {
@@ -78,10 +88,12 @@ const bar = {
   }
 }
 
-export default {
+const defaultTheme: ThemeType = {
   button,
   card,
   charts: {
     bar
   }
 }
+
+export default defaultTheme

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,1 +1,12 @@
+import colors from './values/colors'
+import dimensions from './values/dimensions'
+import typography from './values/typography'
+
 export { default } from './default'
+export type { ThemeType } from './types'
+
+export const defaultValues = {
+  colors,
+  dimensions,
+  typography
+}

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -1,0 +1,77 @@
+import * as CSS from 'csstype'
+
+export interface BaseButtonType {
+  background?: CSS.Property.Background
+  padding?: CSS.Property.Padding
+  border?: {
+    color?: CSS.Property.BorderColor
+    width?: CSS.Property.BorderWidth
+    radius?: CSS.Property.BorderRadius
+  }
+  text?: {
+    color?: CSS.Property.Color
+    size?: CSS.Property.FontSize
+    weight?: CSS.Property.FontWeight
+    transform?: CSS.Property.TextTransform
+  }
+}
+
+export interface ButtonType {
+  regular?: BaseButtonType
+  active?: BaseButtonType
+}
+
+export interface CardType {
+  background?: CSS.Property.Background
+  padding?: CSS.Property.Padding
+  shadow?: CSS.Property.BoxShadow
+  border?: {
+    radius?: CSS.Property.BorderRadius
+  }
+  title?: {
+    size?: CSS.Property.FontSize
+    weight?: CSS.Property.FontWeight
+    color?: CSS.Property.Color
+  }
+  content?: {
+    size?: CSS.Property.FontSize
+    weight?: CSS.Property.FontWeight
+    color?: CSS.Property.Color
+    margin?: CSS.Property.Margin
+    editButton?: {
+      padding?: CSS.Property.Padding
+      background?: CSS.Property.Background
+      border?: {
+        radius?: CSS.Property.BorderRadius
+        width?: CSS.Property.BorderWidth
+      }
+      width?: CSS.Property.Width
+      height?: CSS.Property.Height
+      right?: CSS.Property.Right
+      top?: CSS.Property.Top
+    }
+  }
+}
+
+export interface BarChartType {
+  fill?: CSS.Property.Fill
+  size?: number
+  value?: {
+    color?: CSS.Property.Color
+    weight?: CSS.Property.FontWeight
+    size?: number
+  }
+  name?: {
+    color?: CSS.Property.Color
+    weight?: CSS.Property.FontWeight
+    size?: number
+  }
+}
+
+export interface ThemeType {
+  button?: ButtonType
+  card?: CardType
+  charts?: {
+    bar?: BarChartType
+  }
+}

--- a/src/theme/values/typography.ts
+++ b/src/theme/values/typography.ts
@@ -1,17 +1,17 @@
 export default {
   button: {
     size: '12px',
-    weight: '600',
+    weight: 600,
     transform: 'uppercase'
   },
   card: {
     title: {
       size: '14px',
-      weight: '400'
+      weight: 400
     },
     content: {
       size: '16px',
-      weight: '600'
+      weight: 600
     }
   },
   charts: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4150,7 +4150,7 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^3.0.2:
+csstype@^3.0.2, csstype@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.7.tgz#2a5fb75e1015e84dd15692f71e89a1450290950b"
   integrity sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==


### PR DESCRIPTION
## Types of changes

- Refactoring

## Description of the proposed changes

The theme object contains mostly CSS rules, but only some are supported/configurable. This will add
a type definition for the theme object to allow ease of use when customizing the theme, providing a
clear definition of what can be edited and what kind of CSS rule values are supported.

fix #10 