### PR TITLE
feat(circular gauge): add the circular gauge component

### DIFF
--- a/example/src/stories/CircularGauge.stories.tsx
+++ b/example/src/stories/CircularGauge.stories.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { CircularGauge } from '@loadsmart/data-visualization'
+import {Story} from "@storybook/react/types-6-0";
+import {ThemeType} from "../../../src";
+
+export default {
+  title: 'Circular Gauge',
+  component: CircularGauge,
+  argTypes: {
+    value: {
+      control: 'number'
+    },
+    max: {
+      control: 'number'
+    },
+    width: {
+      control: 'number'
+    },
+    height: {
+      control: 'number'
+    },
+    barBackground: {
+      control: 'color'
+    },
+    valueWeight: {
+      control: 'number'
+    },
+    valueSize: {
+      control: 'number'
+    },
+    valueColor: {
+      control: 'color'
+    },
+    showAsPercentage: {
+      control: 'boolean'
+    },
+    barFill: {
+      control: 'color'
+    }
+  }
+}
+
+interface ArgsTypes {
+  height: number
+  width: number
+  max: number
+  value: number
+  barBackground: string
+  valueWeight: number
+  valueSize: number
+  valueColor: string
+  showAsPercentage: boolean
+  barFill: string
+}
+
+const Template:Story<ArgsTypes> = ({height, max, value, width, barBackground, valueWeight, valueSize, valueColor, showAsPercentage, barFill}) => {
+  const theme:ThemeType = {
+    gauges: {
+      circular: {
+        value: {
+          weight: valueWeight,
+          size: valueSize,
+          color: valueColor
+        },
+        barBackground,
+        barFill,
+        width,
+        height,
+      }
+    }
+  }
+
+  return <CircularGauge max={max} value={value} theme={theme} showAsPercentage={showAsPercentage}/>
+}
+
+export const DefaultTheme = Template.bind({})
+DefaultTheme.args = {
+  max: 100,
+  value: 50,
+  width: 100,
+  height: 40
+}
+
+export const CustomTheme = Template.bind({})
+CustomTheme.args = {
+  max: 100,
+  value: 50,
+  width: 200,
+  height: 200,
+  barFill: '#ff0000',
+  barBackground: '#888',
+  valueColor: 'blue',
+  valueSize: 80,
+  valueWeight: 600,
+}
+
+export const PercentageBased = Template.bind({})
+PercentageBased.args = {
+  max: 19000,
+  value: 1000,
+  width: 40,
+  height: 40,
+  showAsPercentage: true
+}

--- a/src/components/BarChart/BarChart.test.tsx
+++ b/src/components/BarChart/BarChart.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import BarChart from './BarChart'
-import { ColorsType, DataType } from './BarChart.types'
+import { BarChartDataType, BarChartColorsType } from './BarChart.types'
 import defaultTheme from '../../theme'
 
-const mockData: DataType[] = [
+const mockData: BarChartDataType[] = [
   {
     name: 'Foo',
     value: 0
@@ -52,7 +52,7 @@ describe('BarChart Component', () => {
   })
 
   it('colors bars according to the colors "from" rules', async () => {
-    const fromColors: ColorsType[] = [
+    const fromColors: BarChartColorsType[] = [
       { from: 50, color: 'blue' },
       { from: 0, color: 'red' }
     ]
@@ -79,7 +79,7 @@ describe('BarChart Component', () => {
   })
 
   it('colors bars according to the colors "to" rules', async () => {
-    const fromColors: ColorsType[] = [
+    const fromColors: BarChartColorsType[] = [
       { to: 50, color: 'orange' },
       { to: 100, color: 'pink' }
     ]
@@ -106,7 +106,7 @@ describe('BarChart Component', () => {
   })
 
   it('colors bars according to the colors range rules, with fallback to default', async () => {
-    const fromColors: ColorsType[] = [
+    const fromColors: BarChartColorsType[] = [
       { from: 0, to: 20, color: 'brown' },
       // { from: 21, to: 40, color: 'should fall back to default' },
       { from: 41, to: 60, color: 'grey' },
@@ -126,7 +126,7 @@ describe('BarChart Component', () => {
     ).toBe('brown')
     expect(
       container?.querySelector('path[name=Bar]')?.getAttribute('fill')
-    ).toBe(defaultTheme.charts.bar.fill)
+    ).toBe(defaultTheme.charts!.bar!.fill)
     expect(
       container?.querySelector('path[name=Boo]')?.getAttribute('fill')
     ).toBe('grey')

--- a/src/components/CircularGauge/CircularGauge.test.tsx
+++ b/src/components/CircularGauge/CircularGauge.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import {render, screen, waitFor} from '@testing-library/react'
+import CircularGauge from './CircularGauge'
+import { ThemeType } from '../../theme'
+
+const theme: ThemeType = {
+  gauges: {
+    circular: {
+      width: 100,
+      height: 100
+    }
+  }
+}
+
+describe('Circular Gauge Component', () => {
+  it('renders without crashing', () => {
+    render(<CircularGauge value={10} max={100} theme={{}} />)
+  })
+
+  it('renders with correct value', async () => {
+    render(<CircularGauge value={10} max={100} theme={theme} />)
+
+    await waitFor(() => screen.getByText('10'), { timeout: 10000 })
+  })
+
+  it('shows as percentage', async () => {
+    render(<CircularGauge value={10} max={50} theme={theme} showAsPercentage />)
+
+    await waitFor(() => screen.getByText('20%'), { timeout: 10000 })
+  })
+})

--- a/src/components/CircularGauge/CircularGauge.tsx
+++ b/src/components/CircularGauge/CircularGauge.tsx
@@ -1,0 +1,112 @@
+import React, { useContext } from 'react'
+import { Cell, Pie, PieChart, ResponsiveContainer } from 'recharts'
+import { CircularGaugeComponent } from './CircularGauge.types'
+import { ThemeContext } from 'styled-components'
+import getFromClosestTheme from '../../utils/getFromClosestTheme'
+
+const CircularGauge: CircularGaugeComponent = ({
+  value,
+  max,
+  showAsPercentage,
+  theme
+}) => {
+  const contextTheme = useContext(ThemeContext)
+
+  const barFill = getFromClosestTheme(
+    'gauges.circular.barFill',
+    theme,
+    contextTheme
+  )
+  const barBackground = getFromClosestTheme(
+    'gauges.circular.barBackground',
+    theme,
+    contextTheme
+  )
+
+  const valueColor = getFromClosestTheme(
+    'gauges.circular.value.color',
+    theme,
+    contextTheme
+  )
+  const valueSize = getFromClosestTheme(
+    'gauges.circular.value.size',
+    theme,
+    contextTheme
+  )
+  const valueWeight = getFromClosestTheme(
+    'gauges.circular.value.weight',
+    theme,
+    contextTheme
+  )
+
+  const width = getFromClosestTheme(
+    'gauges.circular.width',
+    theme,
+    contextTheme
+  )
+  const height = getFromClosestTheme(
+    'gauges.circular.height',
+    theme,
+    contextTheme
+  )
+
+  const renderLabel = (props: any) => {
+    if (props.index) return
+    return (
+      <text
+        x={props.cx + 1}
+        y={props.cy + 1}
+        textAnchor='middle'
+        alignmentBaseline='middle'
+        fontSize={valueSize}
+        fill={valueColor}
+        fontWeight={valueWeight}
+      >
+        {`${props.value}${showAsPercentage ? '%' : ''}`}
+      </text>
+    )
+  }
+
+  const data = [
+    {
+      id: 'value',
+      value: showAsPercentage ? Math.round((value / max) * 100) : value
+    },
+    {
+      id: 'backgorund',
+      value: showAsPercentage ? 100 - (value / max) * 100 : max - value
+    }
+  ]
+
+  // For testing purposes we need to pass down a width and height
+  // In the testing env this would render nothing otherwise
+  // It is a problem with ReCharts' responsive container.
+  // For most applications, having it set to 100% will work fine, making it inherit those from its parent node.
+  return (
+    <ResponsiveContainer width={width || '100%'} height={height || '100%'}>
+      <PieChart>
+        <Pie
+          innerRadius='80%'
+          outerRadius='100%'
+          data={data}
+          startAngle={90}
+          endAngle={-270}
+          dataKey='value'
+          paddingAngle={0}
+          label={renderLabel}
+          labelLine={false}
+        >
+          {data.map((entry, index) => (
+            <Cell
+              key={`circularGaugeCell_${entry.id}`}
+              fill={index ? barBackground : barFill}
+              stroke='none'
+            />
+          ))}
+        </Pie>
+      </PieChart>
+    </ResponsiveContainer>
+  )
+}
+
+export default CircularGauge

--- a/src/components/CircularGauge/CircularGauge.types.ts
+++ b/src/components/CircularGauge/CircularGauge.types.ts
@@ -1,0 +1,12 @@
+import { ThemeType } from '../../theme'
+import { FC } from 'react'
+
+export interface CircularGaugePropsType {
+  value: number
+  showAsPercentage?: boolean
+  max: number
+  theme?: ThemeType
+  width?: number
+}
+
+export interface CircularGaugeComponent extends FC<CircularGaugePropsType> {}

--- a/src/components/CircularGauge/index.ts
+++ b/src/components/CircularGauge/index.ts
@@ -1,0 +1,2 @@
+export { default } from './CircularGauge'
+export type { CircularGaugePropsType } from './CircularGauge.types'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,5 +15,8 @@ export type {
   BarChartColorsType
 } from './components/BarChart'
 
+export { default as CircularGauge } from './components/CircularGauge'
+export type { CircularGaugePropsType } from './components/CircularGauge'
+
 export type { ThemeType } from './theme'
 export { default as DefaultTheme, defaultValues } from './theme'

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -7,7 +7,7 @@ import {
   BarChartType,
   BaseButtonType,
   ButtonType,
-  CardType,
+  CardType, CircularGaugeType,
   ThemeType
 } from './types'
 
@@ -88,11 +88,24 @@ const bar: BarChartType = {
   }
 }
 
+const circular: CircularGaugeType = {
+  barFill: colors.neutral.darker,
+  barBackground: colors.neutral.light,
+  value: {
+    color: colors.neutral.darker,
+    size: typography.charts.size,
+    weight: typography.charts.weight
+  }
+}
+
 const defaultTheme: ThemeType = {
   button,
   card,
   charts: {
     bar
+  },
+  gauges: {
+    circular
   }
 }
 

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -68,10 +68,25 @@ export interface BarChartType {
   }
 }
 
+export interface CircularGaugeType {
+  barFill?: CSS.Property.Fill
+  barBackground?: CSS.Property.Fill
+  width?: number
+  height?: number
+  value?: {
+    size?: number
+    color?: CSS.Property.Color | undefined
+    weight?: CSS.Property.FontWeight
+  }
+}
+
 export interface ThemeType {
   button?: ButtonType
   card?: CardType
   charts?: {
     bar?: BarChartType
+  }
+  gauges?: {
+    circular?: CircularGaugeType
   }
 }

--- a/src/theme/values/colors.ts
+++ b/src/theme/values/colors.ts
@@ -2,6 +2,7 @@ export default {
   neutral: {
     darkest: '#0A0A0B',
     darker: '#313336',
+    light: '#CFD8DC',
     lighter: '#E9EBEC',
     lightest: '#FFFFFF'
   },


### PR DESCRIPTION
## Types of changes

- New feature

## Description of the proposed changes

This PR will, once merged, add the circular gauge component, its type definitions, tests, storybook stories, index exports and
theming.

Here is how it looks:

Simple usage:
![image](https://user-images.githubusercontent.com/8506849/115314922-91c31600-a14c-11eb-88a2-43608ecbacac.png)
Fully customizable theme:
![image](https://user-images.githubusercontent.com/8506849/115314941-9d164180-a14c-11eb-8f65-058055026898.png)
Percentage display:
![image](https://user-images.githubusercontent.com/8506849/115314952-a56e7c80-a14c-11eb-9743-333338cb6970.png)
