### PR TITLE
fix(circular-gauge): fix label rendering issue

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+const App = () => <div>Use 'yarn start' to see the storybook.</div>
+
+ReactDOM.render(<App />, document.getElementById('root'))

--- a/src/components/CircularGauge/CircularGauge.tsx
+++ b/src/components/CircularGauge/CircularGauge.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useCallback, useContext, useMemo } from 'react'
 import { Cell, Pie, PieChart, ResponsiveContainer } from 'recharts'
 import { CircularGaugeComponent } from './CircularGauge.types'
 import { ThemeContext } from 'styled-components'
@@ -51,38 +51,44 @@ const CircularGauge: CircularGaugeComponent = ({
     contextTheme
   )
 
-  const renderLabel = (props: any) => {
-    if (props.index) return
-    return (
-      <text
-        x={props.cx + 1}
-        y={props.cy + 1}
-        textAnchor='middle'
-        alignmentBaseline='middle'
-        fontSize={valueSize}
-        fill={valueColor}
-        fontWeight={valueWeight}
-      >
-        {`${props.value}${showAsPercentage ? '%' : ''}`}
-      </text>
-    )
-  }
-
-  const data = [
-    {
-      id: 'value',
-      value: showAsPercentage ? Math.round((value / max) * 100) : value
+  const renderLabel = useCallback(
+    (props: any) => {
+      if (props.index) return ''
+      return (
+        <text
+          x={props.cx + 1}
+          y={props.cy + 1}
+          textAnchor='middle'
+          alignmentBaseline='middle'
+          fontSize={valueSize}
+          fill={valueColor}
+          fontWeight={valueWeight}
+        >
+          {`${props.value}${showAsPercentage ? '%' : ''}`}
+        </text>
+      )
     },
-    {
-      id: 'backgorund',
-      value: showAsPercentage ? 100 - (value / max) * 100 : max - value
-    }
-  ]
+    [showAsPercentage, valueSize, valueColor, valueWeight]
+  )
+
+  const data = useMemo(
+    () => [
+      {
+        id: 'value',
+        value: showAsPercentage ? Math.round((value / max) * 100) : value
+      },
+      {
+        id: 'background',
+        value: showAsPercentage ? 100 - (value / max) * 100 : max - value
+      }
+    ],
+    [showAsPercentage, value, max]
+  )
 
   // For testing purposes we need to pass down a width and height
-  // In the testing env this would render nothing otherwise
-  // It is a problem with ReCharts' responsive container.
-  // For most applications, having it set to 100% will work fine, making it inherit those from its parent node.
+  //  In the testing env this would render nothing otherwise
+  //  It is a problem with ReCharts' responsive container.
+  //  For most applications, having it set to 100% will work fine, making it inherit those from its parent node.
   return (
     <ResponsiveContainer
       width={responsive ? '100%' : width}


### PR DESCRIPTION
## Types of changes

- Bugfix

## Description of the proposed changes

There is a known bug that causes the chart label to not render properly if the chart is animated.
It is discussed here: https://github.com/recharts/recharts/issues/929

It should appear like this (and it does in the storybook/example):
![image](https://user-images.githubusercontent.com/8506849/115555621-15cce900-a286-11eb-8caa-70b268d97ebd.png)

But it currently looks like this when imported and used from another project:
![image](https://user-images.githubusercontent.com/8506849/115556082-a277a700-a286-11eb-82eb-ea5a9a16a14b.png)

For future reference, the solution is to `useMemo` on the `data` array and `useCallback` on the `renderLabel` function, memoizing both. This way we don't lose animation capabilities and don't need to mess with workarounds (like random key props to force re-rendering)

Thanks to @gutofoletto and @BrunoAzzi for helping with debugging this.